### PR TITLE
Fix long delay when switching chunks in GUI

### DIFF
--- a/savegame_reader/gui.py
+++ b/savegame_reader/gui.py
@@ -53,9 +53,12 @@ class SavegameBrowser:
         chunk = self.chunks[self.chunks.focus].original_widget.label
 
         if self._savegame.items[chunk]:
+            entries = []
             for key in self._savegame.items[chunk].keys():
                 button = urwid.Button(str(key))
-                self.indexes.append(urwid.AttrMap(button, None, focus_map="reversed"))
+                entries.append(urwid.AttrMap(button, None, focus_map="reversed"))
+            self.indexes.extend(entries)
+            self.indexes.set_focus(0)
 
     def add_table(self, tables, fields, table_key="root", prefix=""):
         table = tables[table_key]


### PR DESCRIPTION
Switching to a new chunk in the GUI can lead to a long delay (e.g. 10+ seconds of waiting) for table chunks with a moderately large number of entries.

This is due to IndexFocus being unnecessarily called for every entry in the chunk. This function performs a non-trivial amount of reconfiguration work.
Avoiding this reduces the above delay to less than 1 second.